### PR TITLE
Fix uncompatible dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
+huggingface_hub==0.16.4
 numpy==1.24.4
 scipy==1.10.1
 scikit-image==0.21.0
 opencv-python==4.7.0.72
 pillow==9.4.0
 diffusers==0.24.0
-transformers==4.36.2
+transformers==4.35.0
 accelerate==0.26.1
 matplotlib==3.7.4
 tqdm==4.64.1
@@ -12,3 +13,4 @@ gradio==4.16.0
 config==0.5.1
 einops==0.7.0
 onnxruntime==1.16.2
+basicsr


### PR DESCRIPTION
while trying to use the repo with the enviroment you have specified i ran into some issues. because hugginface hub isnt installed directly but as a sub-dependency a newer version is installed that doesnt have the functions that this repos code uses.

i have updated the version of transformers and added a compatible  huggingface version and also added basicsr which the code uses but isnt specified in the requirements.

tested on arch linux and ubuntu
